### PR TITLE
Properly re-raise an exception. No longer hides the exception stack.

### DIFF
--- a/flask_principal/__init__.py
+++ b/flask_principal/__init__.py
@@ -222,8 +222,7 @@ class IdentityContext(object):
 
     def __exit__(self, *exc):
         if exc != (None, None, None):
-            cls, val, tb = exc
-            raise(cls, val, tb)
+            raise
         return False
 
 


### PR DESCRIPTION
It seems like Principal is 'eating' exception details when re-raising in the **exit** method.

Calling raise will automatically re-raise the previous exception and it does not hide the stack.
