### PR TITLE
Pertaining to Issue #7

### DIFF
--- a/flask_principal/__init__.py
+++ b/flask_principal/__init__.py
@@ -380,15 +380,15 @@ class Principal(object):
         self.use_sessions = use_sessions
         self.skip_static = skip_static
 
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
         if hasattr(app, 'static_url_path'):
             self._static_path = app.static_url_path
         else:
             self._static_path = app.static_path
 
-        if app is not None:
-            self._init_app(app)
-
-    def _init_app(self, app):
         app.before_request(self._on_before_request)
         identity_changed.connect(self._on_identity_changed, app)
 


### PR DESCRIPTION
The below is now valid. I made `init_app(app)` public method.

``` python
principals = Principal()

def create_app():
    app = Flask()
    principals.init_app(app)

   return app
```

I do not know how you would want to note that in the documentation.
