### PR TITLE
Version fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Flask-Principal release.
 Version 0.4.0
 -------------
 
-Not released yet
+Released June 14th 2013
 
 - Added Python 3 support
 - Dropped support for Python 2.5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ copyright = u'2012, Ali Afshar'
 # built documents.
 #
 # The short X.Y version.
-version = '0.3.5'
+version = '0.4.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flask_principal.py
+++ b/flask_principal.py
@@ -12,7 +12,7 @@
 
 from __future__ import with_statement
 
-__version__ = '0.3.5'
+__version__ = '0.4.0'
 
 import sys
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -90,8 +90,8 @@ def set_filename_version(filename, version_number, pattern):
 
 
 def set_init_version(version):
-    info('Setting __init__.py version to %s', version)
-    set_filename_version('flask_principal/__init__.py', version, '__version__')
+    info('Setting flask_principal.py version to %s', version)
+    set_filename_version('flask_principal.py', version, '__version__')
 
 
 def set_setup_version(version):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Principal',
-    version='0.3.5',
+    version='0.4.0',
     url='http://packages.python.org/Flask-Principal/',
     license='MIT',
     author='Ali Afshar',


### PR DESCRIPTION
Master is still tagged with version `0.3.5`.
This branch merged the tip `0.4.0` with master to reflect the changes
