### PR TITLE
chore: update flask-principal version

### DIFF
--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -12,7 +12,7 @@
 
 from __future__ import with_statement
 
-__version__ = '0.3.5'
+__version__ = '0.4.0'
 
 import sys
 


### PR DESCRIPTION
Update flask-principal version to 0.4.0. But, @aenglander do we need it? Can we remove it?