### PR TITLE
Refactor to avoid conflicts between Permission.excludes and Permission.needs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Unreleased
 
 - Added Pallets projects scaffolding
 - Updated docstrings. Changed ``flask.ext.principal`` imports to ``flask_principal``.
+- Updated ``Permission`` needs and excludes to never conflict with each other.
 
 Version 0.4.0
 -------------


### PR DESCRIPTION
We can get into a weird state with conflicting logic by doing the following:
```
d = Denial(('a', 'c'))
p = Permission(('a', 'c'))

u = d.union(p)
#  now u has ('a', 'c') in BOTH needs and excludes
```
With this refactoring, a need can be needed or excluded, but not both. This change is not expected to break anything and just handle the edge case described above.