### PR TITLE
Docs: Update URLs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ The major components are the Identity, Needs, Permission, and the IdentityContex
 Links
 -----
 
-* `source <http://github.com/mattupstate/flask-principal>`_
+* `source <http://github.com/pallets-eco/flask-principal>`_
 * :doc:`changelog </changelog>`
 
 Protecting access to resources

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,6 @@ The major components are the Identity, Needs, Permission, and the IdentityContex
 Links
 -----
 
-* `documentation <http://packages.python.org/Flask-Principal/>`_
 * `source <http://github.com/mattupstate/flask-principal>`_
 * :doc:`changelog </changelog>`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,7 +115,7 @@ Authentication providers
 Authentication providers should use the `identity-changed` signal to indicate
 that a request has been authenticated. For example, the following code is a
 hypothetical example of how one might combine the popular 
-`Flask-Login <http://packages.python.org/Flask-Login/>`_  extension with 
+`Flask-Login <https://flask-login.readthedocs.io/>`_  extension with 
 Flask-Principal::
 
 


### PR DESCRIPTION
Glad to see this extension becoming adopted by Pallets-Eco!

I propose these minor changes to the docs:
- Remove link from documentation to itself
- Update repo URL
- Update Flask-Login docs URL