### PR TITLE
Fix build with Sphinx 8.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,7 +290,7 @@ epub_copyright = u'2012, Matt Wright'
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
 
 pygments_style = 'flask_theme_support.FlaskyStyle'
 


### PR DESCRIPTION
When building on Arch Linux, Sphinx complains current configuration:

```
ERROR: Invalid value `None` in intersphinx_mapping['https://docs.python.org/']. Expected a two-element tuple or list.
```

Change intersphinx_mapping to match https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html fixes the issue.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
