### PR TITLE
Rebase of PR-21 (Match operations with permission objects with set operators)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -314,6 +314,54 @@ of the resource, in this case the blog post::
 
         abort(403)  # HTTP Forbidden
 
+Combining Permissions
+---------------------
+
+While the core constructs provided are sufficient for the common simple use
+cases, for more complex cases it is possible to combine existing permissions
+through the use of bitwise operators to result in a new permission object that
+can do the complex validations.  For instance, it is to create a permission
+where the identity has the both the `"blog_poster"` or `"blog_reviewer"` role
+but not the `"under_probation"` role.  Example:: 
+
+    blog_admin = Permission(RoleNeed('blog_admin'))
+    blog_poster = Permission(RoleNeed('blog_poster'))
+    blog_reviewer = Permission(RoleNeed('blog_reviewer'))
+    under_probation = Permission(RoleNeed('under_probation'))
+
+    prize_permission = ((blog_poster | blog_reviewer) & ~under_probation)
+
+    @app.route('/blog/prizes')
+    @prize_permission.require()
+    def prize_redeem():
+        # find out what prizes are available to blog users that are not
+        # under probation
+        return render_template('prize_redeem.html')
+
+Any number of these can be chained, but it is also possible to use the
+constructor classes directly to combine these things together::
+
+    from flask.ext.principal import AndPermission, OrPermission
+
+    allperms = AndPermission(blog_poster, blog_reviewer, blog_admin)
+    anyperms = OrPermission(blog_poster, blog_reviewer, blog_admin)
+
+Custom Permissions
+------------------
+
+Sometimes your permissions may be determined by other circumstances specific to
+whatever you need to implement.  For that you can create custom classes to
+address your needs like so::
+
+    from flask.ext.principal import BasePermission
+
+    class CustomPermission(BasePermission):
+        def allows(self, identity):
+            # Implement other conditions that allow this to pass
+            return False
+
+These custom permissions can be combined together via the bitwise operators as
+explained above.
 
 API
 ===

--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -234,6 +234,11 @@ class BasePermission(object):
         """
         return OrPermission(self, other)
 
+    def __and__(self, other):
+        """See ``AndPermission``.
+        """
+        return AndPermission(self, other)
+
     def require(self, http_exception=None):
         """Create a principal for this permission.
 
@@ -305,6 +310,23 @@ class OrPermission(_NaryOperatorPermission):
             if p.allows(identity):
                 return True
         return False
+
+
+class AndPermission(_NaryOperatorPermission):
+    """Result of bitwise ``and`` of BasePermission"""
+
+    def allows(self, identity):
+        """
+        Checks for any of the nested permission instances that disallow
+        the identity and return False, else return True.
+
+        :param identity: The identity.
+        """
+
+        for p in self.permissions:
+            if not p.allows(identity):
+                return False
+        return True
 
 
 class Permission(BasePermission):

--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -232,16 +232,25 @@ class BasePermission(object):
     def __or__(self, other):
         """See ``OrPermission``.
         """
+        return self.or_(other)
+
+    def or_(self, other):
         return OrPermission(self, other)
 
     def __and__(self, other):
         """See ``AndPermission``.
         """
+        return self.and_(other)
+
+    def and_(self, other):
         return AndPermission(self, other)
 
     def __invert__(self):
         """See ``NotPermission``.
         """
+        return self.invert()
+
+    def invert(self):
         return NotPermission(self)
 
     def require(self, http_exception=None):
@@ -349,7 +358,7 @@ class NotPermission(BasePermission):
     def __init__(self, permission):
         self.permission = permission
 
-    def __invert__(self):
+    def invert(self):
         return self.permission
 
     def allows(self, identity):

--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -239,6 +239,11 @@ class BasePermission(object):
         """
         return AndPermission(self, other)
 
+    def __invert__(self):
+        """See ``NotPermission``.
+        """
+        return NotPermission(self)
+
     def require(self, http_exception=None):
         """Create a principal for this permission.
 
@@ -295,6 +300,9 @@ class _NaryOperatorPermission(BasePermission):
         self.permissions = set(permissions)
 
 
+# These classes would be unnecessary if we have predicate calculus
+# primatives of some kind.
+
 class OrPermission(_NaryOperatorPermission):
     """Result of bitwise ``or`` of BasePermission"""
 
@@ -327,6 +335,25 @@ class AndPermission(_NaryOperatorPermission):
             if not p.allows(identity):
                 return False
         return True
+
+
+class NotPermission(BasePermission):
+    """
+    Result of bitwise ``not`` of BasePermission
+
+    Really could be implemented by returning a transformed result of the
+    source class of itself, but for the sake of clear presentation I am
+    not doing that.
+    """
+
+    def __init__(self, permission):
+        self.permission = permission
+
+    def __invert__(self):
+        return self.permission
+
+    def allows(self, identity):
+        return not self.permission.allows(identity)
 
 
 class Permission(BasePermission):

--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -214,6 +214,8 @@ class IdentityContext(object):
 class BasePermission(object):
     """The Base Permission."""
 
+    http_exception = None
+
     def _bool(self):
         return bool(self.can())
 
@@ -239,6 +241,10 @@ class BasePermission(object):
 
         :param http_exception: the HTTP exception code (403, 401 etc)
         """
+
+        if http_exception is None:
+            http_exception = self.http_exception
+
         return IdentityContext(self, http_exception)
 
     def test(self, http_exception=None):

--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -236,12 +236,12 @@ class Permission(object):
         """
         return self._bool()
 
-    def __and__(self, other):
+    def __or__(self, other):
         """Does the same thing as ``self.union(other)``
         """
         return self.union(other)
 
-    def __or__(self, other):
+    def __sub__(self, other):
         """Does the same thing as ``self.difference(other)``
         """
         return self.difference(other)

--- a/src/flask_principal.py
+++ b/src/flask_principal.py
@@ -229,6 +229,11 @@ class BasePermission(object):
         """
         return self._bool()
 
+    def __or__(self, other):
+        """See ``OrPermission``.
+        """
+        return OrPermission(self, other)
+
     def require(self, http_exception=None):
         """Create a principal for this permission.
 
@@ -279,6 +284,29 @@ class BasePermission(object):
         return self.require().can()
 
 
+class _NaryOperatorPermission(BasePermission):
+
+    def __init__(self, *permissions):
+        self.permissions = set(permissions)
+
+
+class OrPermission(_NaryOperatorPermission):
+    """Result of bitwise ``or`` of BasePermission"""
+
+    def allows(self, identity):
+        """
+        Checks for any of the nested permission instances that allow the
+        identity and return True, else return False.
+
+        :param identity: The identity.
+        """
+
+        for p in self.permissions:
+            if p.allows(identity):
+                return True
+        return False
+
+
 class Permission(BasePermission):
     """Represents needs, any of which must be present to access a resource
 
@@ -294,7 +322,9 @@ class Permission(BasePermission):
     def __or__(self, other):
         """Does the same thing as ``self.union(other)``
         """
-        return self.union(other)
+        if isinstance(other, Permission):
+            return self.union(other)
+        return super(Permission, self).__or__(other)
 
     def __sub__(self, other):
         """Does the same thing as ``self.difference(other)``

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -353,7 +353,7 @@ class PrincipalApplicationTests(unittest.TestCase):
 
         response = self.client.open('/o3')
         assert response.status_code == 200
-        assert response.data == 'OK'
+        assert response.data == b'OK'
 
     def test_permission_test_with_http_exc(self):
         response = self.client.open("/p")

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -222,13 +222,28 @@ def mkapp(with_factory=False):
 
         i = Identity('manager_editor')
         identity_changed.send(app, identity=i)
-        with mixed_perms.require():
+        if mixed_perms.can():
             result.append('good')
+
+        i = Identity('manager')
+        identity_changed.send(app, identity=i)
+        if mixed_perms.can():
+            result.append('bad')
+
+        i = Identity('editor')
+        identity_changed.send(app, identity=i)
+        if mixed_perms.can():
+            result.append('bad')
 
         i = Identity('admin_editor')
         identity_changed.send(app, identity=i)
-        with mixed_perms.require():
+        if mixed_perms.can():
             result.append('good')
+
+        i = Identity('admin')
+        identity_changed.send(app, identity=i)
+        if mixed_perms.can():
+            result.append('bad')
 
         return Response(''.join(result))
 

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -16,8 +16,17 @@ admin_denied = Denial(RoleNeed('admin'))
 
 
 def _on_principal_init(sender, identity):
-    if identity.id == 'ali':
-        identity.provides.add(RoleNeed('admin'))
+    role_map = {
+        'ali': (RoleNeed('admin'),),
+        'admin': (RoleNeed('admin'),),
+        'editor': (RoleNeed('editor'),),
+        'admin_editor': (RoleNeed('editor'), RoleNeed('admin')),
+    }
+
+    roles = role_map.get(identity.id)
+    if roles:
+        for role in roles:
+            identity.provides.add(role)
 
 
 class ReraiseException(Exception):

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -187,23 +187,33 @@ class PrincipalUnitTests(unittest.TestCase):
         d = p.reverse()
         assert ('a', 'b') in d.excludes
 
-    def test_permission_and(self):
+    def test_permission_difference(self):
         p1 = Permission(RoleNeed('boss'))
         p2 = Permission(RoleNeed('lackey'))
 
-        p3 = p1 & p2
-        p4 = p1.union(p2)
+        p3 = p1 - p2
+        p4 = p1.difference(p2)
+
+        # parity with set operations
+        p3needs = p1.needs - p2.needs
 
         assert p3.needs == p4.needs
+        assert p3.needs == p3needs
 
     def test_permission_or(self):
         p1 = Permission(RoleNeed('boss'), RoleNeed('lackey'))
         p2 = Permission(RoleNeed('lackey'), RoleNeed('underling'))
 
         p3 = p1 | p2
-        p4 = p1.difference(p2)
+        p4 = p1.union(p2)
+
+        # Ensure that an `or` between sets also result in the expected
+        # behavior.  As expected, as "any of which must be present to 
+        # access a resource".
+        p3needs = p1.needs | p2.needs
 
         assert p3.needs == p4.needs
+        assert p3.needs == p3needs
 
     def test_contains(self):
         p1 = Permission(RoleNeed('boss'), RoleNeed('lackey'))

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -260,14 +260,13 @@ def mkapp(with_factory=False):
 
     @app.route('/mixed_ops_fail')
     def mixed_ops_fail():
-        result = []
         mixed_perms = (admin_permission | manager_permission |
             (reviewer_role_permission & editor_role_permission))
 
         i = Identity('editor')
         identity_changed.send(app, identity=i)
         with mixed_perms.require():
-            result.append('fail')
+            return Response('fail')
 
     @app.route('/mixed_ops1')
     def mixed_ops1():

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -6,6 +6,7 @@ import unittest
 from flask import Flask, Response
 
 from flask_principal import BasePermission, OrPermission, AndPermission
+from flask_principal import NotPermission
 from flask_principal import Principal, Permission, Denial, RoleNeed, \
     PermissionDenied, identity_changed, Identity, identity_loaded
 
@@ -43,6 +44,8 @@ def _on_principal_init(sender, identity):
         'manager_editor': (RoleNeed('editor'), RoleNeed('manager')),
         'reviewer_editor': (RoleNeed('editor'), RoleNeed('reviewer')),
         'admin_manager': (RoleNeed('admin'), RoleNeed('manager')),
+        'admin_editor_manager': (
+            RoleNeed('admin'), RoleNeed('editor'), RoleNeed('manager')),
     }
 
     roles = role_map.get(identity.id)
@@ -125,6 +128,34 @@ def mkapp(with_factory=False):
         with admin_and_editor_rp.require():
             return Response('good')
 
+    @app.route('/and_bunch')
+    def and_bunch():
+        result = []
+
+        bunch = AndPermission(
+            admin_role_permission,
+            editor_role_permission,
+            manager_role_permission,
+        )
+
+        identity_changed.send(app, identity=Identity('admin'))
+        if bunch.can():
+            result.append('bad')
+
+        identity_changed.send(app, identity=Identity('manager'))
+        if bunch.can():
+            result.append('bad')
+
+        identity_changed.send(app, identity=Identity('reviewer'))
+        if bunch.can():
+            result.append('bad')
+
+        identity_changed.send(app, identity=Identity('admin_editor_manager'))
+        if bunch.can():
+            result.append('good')
+
+        return ''.join(result)
+
     @app.route('/and_mixed1')
     def and_mixed1():
         admin_and_editor_mixed = (admin_role_permission & editor_permission)
@@ -148,6 +179,31 @@ def mkapp(with_factory=False):
         identity_changed.send(app, identity=i)
         with admin_or_editor_rp.require():
             return Response('hello')
+
+    @app.route('/or_bunch')
+    def or_bunch():
+        result = []
+
+        bunch = OrPermission(
+            admin_role_permission,
+            editor_role_permission,
+            manager_role_permission,
+            reviewer_role_permission,
+        )
+
+        identity_changed.send(app, identity=Identity('admin'))
+        if bunch.can():
+            result.append('good')
+
+        identity_changed.send(app, identity=Identity('manager'))
+        if bunch.can():
+            result.append('good')
+
+        identity_changed.send(app, identity=Identity('reviewer'))
+        if bunch.can():
+            result.append('good')
+
+        return ''.join(result)
 
     @app.route('/or_mixed1')
     def or_mixed1():
@@ -553,6 +609,9 @@ class PrincipalApplicationTests(unittest.TestCase):
     def test_base_or_permissions(self):
         assert self.client.open('/or_base').data == b'hello'
 
+    def test_or_permissions_bunch(self):
+        self.assertEqual(self.client.open('/or_bunch').data, b'goodgoodgood')
+
     def test_base_not_permissions(self):
         self.assertEqual(self.client.open('/not_base').data, b'editor')
 
@@ -596,6 +655,9 @@ class PrincipalApplicationTests(unittest.TestCase):
     def test_and_permissions_view_with_http_exc_decorated(self):
         response = self.client.open("/k")
         assert response.status_code == 403
+
+    def test_and_permissions_bunch(self):
+        self.assertEqual(self.client.open('/and_bunch').data, b'good')
 
     def test_and_permissions_view_with_custom_errhandler(self):
         app = mkapp()

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -146,6 +146,13 @@ def mkapp(with_factory=False):
         (admin_permission | editor_permission).test()
         return Response("OK")
 
+    @app.route("/o3")
+    def o3():
+        i = mkadmin()
+        identity_changed.send(app, identity=i)
+        (admin_permission | editor_permission).test()
+        return Response("OK")
+
     @app.route("/p")
     def p():
         admin_or_editor.test(404)
@@ -340,7 +347,13 @@ class PrincipalApplicationTests(unittest.TestCase):
 
     def test_permission_test(self):
         self.assertRaises(PermissionDenied, self.client.open, '/o')
+
+    def test_permission_operator_test(self):
         self.assertRaises(PermissionDenied, self.client.open, '/o2')
+
+        response = self.client.open('/o3')
+        assert response.status_code == 200
+        assert response.data == 'OK'
 
     def test_permission_test_with_http_exc(self):
         response = self.client.open("/p")

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -200,6 +200,19 @@ class PrincipalUnitTests(unittest.TestCase):
         assert p3.needs == p4.needs
         assert p3.needs == p3needs
 
+    def test_permission_difference_excludes(self):
+        p1 = Permission(RoleNeed('boss')).reverse()
+        p2 = Permission(RoleNeed('lackey')).reverse()
+
+        p3 = p1 - p2
+        p4 = p1.difference(p2)
+
+        # parity with set operations
+        p3excludes = p1.excludes - p2.excludes
+
+        assert p3.excludes == p4.excludes
+        assert p3.excludes == p3excludes
+
     def test_permission_or(self):
         p1 = Permission(RoleNeed('boss'), RoleNeed('lackey'))
         p2 = Permission(RoleNeed('lackey'), RoleNeed('underling'))
@@ -214,6 +227,21 @@ class PrincipalUnitTests(unittest.TestCase):
 
         assert p3.needs == p4.needs
         assert p3.needs == p3needs
+
+    def test_permission_or_excludes(self):
+        p1 = Permission(RoleNeed('boss'), RoleNeed('lackey')).reverse()
+        p2 = Permission(RoleNeed('lackey'), RoleNeed('underling')).reverse()
+
+        p3 = p1 | p2
+        p4 = p1.union(p2)
+
+        # Ensure that an `or` between sets also result in the expected
+        # behavior.  As expected, as "any of which must be present to 
+        # access a resource".
+        p3excludes = p1.excludes | p2.excludes
+
+        assert p3.excludes == p4.excludes
+        assert p3.excludes == p3excludes
 
     def test_contains(self):
         p1 = Permission(RoleNeed('boss'), RoleNeed('lackey'))


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
This is a rebase of [PR-21](https://github.com/pallets-eco/flask-principal/pull/21) which implement common set operators for permissions, making it possible to flexibly compose permissions.

Nothing has changed from the original PR other than fixing merge conflicts. If further fixes are required for merge I might be able to get those done.

fixes #110
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
